### PR TITLE
Fix images

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Static HTML export with Nuxt
-        run: yarn generate --no-cache
+        run: yarn generate
       - name: Add CNAME file
         run: echo "p.migdal.pl" > .output/public/CNAME
       - name: Upload artifact

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,5 @@
 // ESLint configured
+import { join } from 'path'
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -83,6 +84,21 @@ export default defineNuxtConfig({
   },
 
   hooks: {
+    'nitro:build:public-assets': async (nitro) => {
+      // Copy blog images after build
+      const { cpSync } = await import('fs')
+      const sourceDir = join(process.cwd(), 'content/blog')
+      const destDir = join(nitro.options.output.publicDir, 'blog')
+
+      cpSync(sourceDir, destDir, {
+        recursive: true,
+        filter: (src) => {
+          return src.includes('.') ? /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(src) : true
+        }
+      })
+
+      console.log('[nitro] ✔ Blog images copied to public directory')
+    },
     close: () => {
       // fixes `nuxi generate` hanging at the end "You can preview this build"
       // @see https://github.com/nuxt/cli/issues/169#issuecomment-1729300497


### PR DESCRIPTION
The --no-cache flag is not necessary and was preventing proper builds. After testing, the standard yarn generate command works correctly and ensures images are properly copied to the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)