### PR TITLE
fix: add browser user-agent to bypass bot detection

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -28,6 +28,7 @@ jobs:
             --max-retries 3
             --timeout 30
             --accept 200,204,206,301,302,307,308,429
+            --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
             './src/content/blog/**/*.md'
             './src/content/blog/**/*.mdx'
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "astro": "astro",
-    "check:links": "lychee --cache --max-cache-age 7d --verbose 'src/content/blog/**/*.md' 'src/content/blog/**/*.mdx'",
-    "check:links:verbose": "lychee --cache --max-cache-age 7d --verbose --no-progress 'src/content/blog/**/*.md' 'src/content/blog/**/*.mdx'",
-    "check:links:nocache": "lychee --verbose 'src/content/blog/**/*.md' 'src/content/blog/**/*.mdx'",
+    "check:links": "lychee --cache --max-cache-age 7d --verbose --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' 'src/content/blog/**/*.md' 'src/content/blog/**/*.mdx'",
+    "check:links:verbose": "lychee --cache --max-cache-age 7d --verbose --no-progress --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' 'src/content/blog/**/*.md' 'src/content/blog/**/*.mdx'",
+    "check:links:nocache": "lychee --verbose --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' 'src/content/blog/**/*.md' 'src/content/blog/**/*.mdx'",
     "check:links:install": "echo 'Install lychee via: brew install lychee (macOS) or cargo install lychee (Rust) or see https://lychee.cli.rs/#/installation'"
   },
   "dependencies": {


### PR DESCRIPTION
Many sites (HackerNews, OpenAI, etc.) block default automated tool user-agents but work fine with browser user-agents. Add Chrome user-agent string to both local scripts and CI workflow to get accurate link checking results.